### PR TITLE
fixes go get command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The implementation in this package has the following features:
 # Install
 
 ```
-go get https://github.com/holoplot/go-evdev
+go get github.com/holoplot/go-evdev
 ```
 
 And then use it in your source code.


### PR DESCRIPTION
Correcting the `go get` command in the README file