### PR TITLE
slight cleanup and fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,3 @@
 module github.com/holoplot/go-evdev
 
 go 1.18
-
-require github.com/stretchr/testify v1.7.0
-
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)

--- a/ioctl.go
+++ b/ioctl.go
@@ -3,6 +3,7 @@ package evdev
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -54,14 +55,14 @@ func ioctlEVIOCGID(fd uintptr) (InputID, error) {
 	return id, err
 }
 
-func ioctlEVIOCGREP(fd uintptr) ([2]uint, error) {
-	rep := [2]uint{}
+func ioctlEVIOCGREP(fd uintptr) ([2]uint32, error) {
+	rep := [2]uint32{}
 	code := ioctlMakeCode(ioctlDirRead, 'E', 0x03, unsafe.Sizeof(rep))
 	err := doIoctl(fd, code, unsafe.Pointer(&rep))
 	return rep, err
 }
 
-func ioctlEVIOCSREP(fd uintptr, rep [2]uint) error {
+func ioctlEVIOCSREP(fd uintptr, rep [2]uint32) error {
 	code := ioctlMakeCode(ioctlDirWrite, 'E', 0x03, unsafe.Sizeof(rep))
 	return doIoctl(fd, code, unsafe.Pointer(&rep))
 }
@@ -82,21 +83,21 @@ func ioctlEVIOCGNAME(fd uintptr) (string, error) {
 	str := [256]byte{}
 	code := ioctlMakeCode(ioctlDirRead, 'E', 0x06, unsafe.Sizeof(str))
 	err := doIoctl(fd, code, unsafe.Pointer(&str))
-	return string(str[:]), err
+	return strings.Trim(string(str[:]), "\x00"), err
 }
 
 func ioctlEVIOCGPHYS(fd uintptr) (string, error) {
 	str := [256]byte{}
 	code := ioctlMakeCode(ioctlDirRead, 'E', 0x07, unsafe.Sizeof(str))
 	err := doIoctl(fd, code, unsafe.Pointer(&str))
-	return string(str[:]), err
+	return strings.Trim(string(str[:]), "\x00"), err
 }
 
 func ioctlEVIOCGUNIQ(fd uintptr) (string, error) {
 	str := [256]byte{}
 	code := ioctlMakeCode(ioctlDirRead, 'E', 0x08, unsafe.Sizeof(str))
 	err := doIoctl(fd, code, unsafe.Pointer(&str))
-	return string(str[:]), err
+	return strings.Trim(string(str[:]), "\x00"), err
 }
 
 func ioctlEVIOCGPROP(fd uintptr) ([]byte, error) {
@@ -193,7 +194,7 @@ func ioctlEVIOCGRAB(fd uintptr, p int32) error {
 }
 
 func ioctlEVIOCREVOKE(fd uintptr) error {
-	var p int
+	var p int32
 	code := ioctlMakeCode(ioctlDirWrite, 'E', 0x91, unsafe.Sizeof(p))
 	return doIoctl(fd, code, nil)
 }

--- a/ioctl.go
+++ b/ioctl.go
@@ -14,6 +14,10 @@ const (
 	ioctlDirRead  = 0x2
 )
 
+func trimNull(s string) string {
+	return strings.Trim(s, "\x00")
+}
+
 func ioctlMakeCode(dir, typ, nr int, size uintptr) uint32 {
 	var code uint32
 	if dir > ioctlDirWrite|ioctlDirRead {
@@ -83,21 +87,21 @@ func ioctlEVIOCGNAME(fd uintptr) (string, error) {
 	str := [256]byte{}
 	code := ioctlMakeCode(ioctlDirRead, 'E', 0x06, unsafe.Sizeof(str))
 	err := doIoctl(fd, code, unsafe.Pointer(&str))
-	return strings.Trim(string(str[:]), "\x00"), err
+	return trimNull(string(str[:])), err
 }
 
 func ioctlEVIOCGPHYS(fd uintptr) (string, error) {
 	str := [256]byte{}
 	code := ioctlMakeCode(ioctlDirRead, 'E', 0x07, unsafe.Sizeof(str))
 	err := doIoctl(fd, code, unsafe.Pointer(&str))
-	return strings.Trim(string(str[:]), "\x00"), err
+	return trimNull(string(str[:])), err
 }
 
 func ioctlEVIOCGUNIQ(fd uintptr) (string, error) {
 	str := [256]byte{}
 	code := ioctlMakeCode(ioctlDirRead, 'E', 0x08, unsafe.Sizeof(str))
 	err := doIoctl(fd, code, unsafe.Pointer(&str))
-	return strings.Trim(string(str[:]), "\x00"), err
+	return trimNull(string(str[:])), err
 }
 
 func ioctlEVIOCGPROP(fd uintptr) ([]byte, error) {


### PR DESCRIPTION
- fix var type in ioctlEVIOCREVOKE
- fix var type in unused ioctlEVIOCGREP and ioctlEVIOCSREP
- null character removal from ioctlEVIOCGUNIQ, ioctlEVIOCGPHYS and ioctlEVIOCGNAME
- remove unused dependencies from go.mod