### PR TITLE
Added support to list available devices, and open them by their name, rather than device path.

### DIFF
--- a/cmd/evtest/main.go
+++ b/cmd/evtest/main.go
@@ -2,35 +2,19 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/holoplot/go-evdev"
 )
 
 func listDevices() {
-	basePath := "/dev/input"
-
-	files, err := ioutil.ReadDir(basePath)
+	devicePaths, err := evdev.ListDevicePaths()
 	if err != nil {
-		fmt.Printf("Cannot read /dev/input: %v\n", err)
+		fmt.Printf("Cannot list device paths: %s", err)
 		return
 	}
-
-	for _, fileName := range files {
-		if fileName.IsDir() {
-			continue
-		}
-
-		full := fmt.Sprintf("%s/%s", basePath, fileName.Name())
-		d, err := evdev.Open(full)
-		if err == nil {
-			name, _ := d.Name()
-
-			if err == nil {
-				fmt.Printf("%s:\t%s\n", d.Path(), name)
-			}
-		}
+	for _, d := range devicePaths {
+		fmt.Printf("%s:\t%s\n", d.Path, d.Name)
 	}
 }
 

--- a/cmd/uinputtest/main.go
+++ b/cmd/uinputtest/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"time"
@@ -11,28 +10,13 @@ import (
 )
 
 func listDevices() {
-	basePath := "/dev/input"
-
-	files, err := ioutil.ReadDir(basePath)
+	devicePaths, err := evdev.ListDevicePaths()
 	if err != nil {
-		fmt.Printf("Cannot read /dev/input: %v\n", err)
+		fmt.Printf("Cannot list device paths: %s", err)
 		return
 	}
-
-	for _, fileName := range files {
-		if fileName.IsDir() {
-			continue
-		}
-
-		full := fmt.Sprintf("%s/%s", basePath, fileName.Name())
-		d, err := evdev.Open(full)
-		if err == nil {
-			name, _ := d.Name()
-
-			if err == nil {
-				fmt.Printf("%s:\t%s\n", d.Path(), name)
-			}
-		}
+	for _, d := range devicePaths {
+		fmt.Printf("%s:\t%s\n", d.Path, d.Name)
 	}
 }
 

--- a/device.go
+++ b/device.go
@@ -34,6 +34,22 @@ func Open(path string) (*InputDevice, error) {
 	return d, nil
 }
 
+// OpenByName creates a new InputDevice from the device name.
+// Returns an error if the name does not exist, or the device node could
+// not be opened or its properties failed to read.
+func OpenByName(name string) (*InputDevice, error) {
+	devices, err := ListDevicePaths()
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range devices {
+		if d.Name == name {
+			return Open(d.Path)
+		}
+	}
+	return nil, fmt.Errorf("could not find input device with name %q", name)
+}
+
 // Close releases the resources held by an InputDevice. After calling this
 // function, the InputDevice is no longer operational.
 func (d *InputDevice) Close() error {

--- a/device.go
+++ b/device.go
@@ -34,7 +34,7 @@ func Open(path string) (*InputDevice, error) {
 	return d, nil
 }
 
-// OpenByName creates a new InputDevice from the device name.
+// OpenByName creates a new InputDevice from the device name as reported by the kernel.
 // Returns an error if the name does not exist, or the device node could
 // not be opened or its properties failed to read.
 func OpenByName(name string) (*InputDevice, error) {

--- a/list.go
+++ b/list.go
@@ -5,11 +5,14 @@ import (
 	"io/ioutil"
 )
 
+// InputPath contains information about an InputDevice Name & Path
 type InputPath struct {
 	Name string
 	Path string
 }
 
+// ListDevicePaths lists all available input devices, returning their
+// filename path, and the name as reported by the kernel.
 func ListDevicePaths() ([]InputPath, error) {
 	var list []InputPath
 

--- a/list.go
+++ b/list.go
@@ -1,0 +1,36 @@
+package evdev
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+type InputPath struct {
+	Name string
+	Path string
+}
+
+func ListDevicePaths() ([]InputPath, error) {
+	var list []InputPath
+
+	basePath := "/dev/input"
+
+	files, err := ioutil.ReadDir(basePath)
+	if err != nil {
+		return list, err
+	}
+
+	for _, fileName := range files {
+		if fileName.IsDir() {
+			continue
+		}
+
+		full := fmt.Sprintf("%s/%s", basePath, fileName.Name())
+		if d, err := Open(full); err == nil {
+			name, _ := d.Name()
+			list = append(list, InputPath{Name: name, Path: d.Path()})
+			d.Close()
+		}
+	}
+	return list, nil
+}


### PR DESCRIPTION
Thanks for this project - the lack of CGO makes it much simpler for doing cross-platform development to embedded Linux targets.
I've just added in a couple of helper functions to make it easier to deal with dynamic device names - we typically scan for the kernel name, rather than the actual `/dev/input` name, to avoid weirdness when we make kernel changes and things get shuffled. This simplifies it a bit, and re-uses that code in the examples.

It is mildly needless in the new `OpenByName` function in that it effectively opens the device twice (once in the scan, and a second time in Open), however this feels minor enough that it's preferable to duplicating the listing code. Happy to take feedback on it though.
