### PR TITLE
If there are no bits back, we get a nil array response, not zero-length

### DIFF
--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -19,7 +19,7 @@ func Test_bitsToArray(t *testing.T) {
 		{
 			name: "2",
 			bits: []byte{},
-			want: []int{},
+			want: nil,
 		},
 		{
 			name: "3",


### PR DESCRIPTION
This was causing `go test` to fail.

I notice that using https://pkg.go.dev/golang.org/x/exp/slices#Equal does do the correct thing (ie: would return true for comparing a nil slice vs. zero-length). But that uses generics, so would bump up the Go version requirements.