### PR TITLE
Fixed file descriptor leak in `Open` method

### DIFF
--- a/device.go
+++ b/device.go
@@ -28,6 +28,7 @@ func Open(path string) (*InputDevice, error) {
 
 	d.driverVersion, err = ioctlEVIOCGVERSION(d.file.Fd())
 	if err != nil {
+		_ = d.file.Close()
 		return nil, fmt.Errorf("cannot get driver version: %v", err)
 	}
 


### PR DESCRIPTION
Close device fd when driver version retrieval fails. An error while closing the file is explicitly ignored.

Fixes #10 