### PR TITLE
Open flags

### DIFF
--- a/list.go
+++ b/list.go
@@ -3,6 +3,7 @@ package evdev
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 )
 
 // InputPath contains information about an InputDevice Name & Path
@@ -29,7 +30,7 @@ func ListDevicePaths() ([]InputPath, error) {
 		}
 
 		full := fmt.Sprintf("%s/%s", basePath, fileName.Name())
-		if d, err := Open(full); err == nil {
+		if d, err := OpenWithFlags(full, os.O_RDONLY); err == nil {
 			name, _ := d.Name()
 			list = append(list, InputPath{Name: name, Path: d.Path()})
 			d.Close()


### PR DESCRIPTION
Added functions `OpenWithFlag` and `OpenByNameWithFlag` to allow opening device nodes with custom flags (RO, RW). This is safer than the previous approach (always open RW)  if one just wants to read from a device.

Existing `Open` and `OpenByName` functions are now calling the new functions with O_RWDR to be backward compatible.

`ListDevicePaths` is now opening devices read only.

I'm happy to take feedback.