### PR TITLE
feat(go): package ioutil is deprecated

### DIFF
--- a/list.go
+++ b/list.go
@@ -2,7 +2,6 @@ package evdev
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -19,7 +18,7 @@ func ListDevicePaths() ([]InputPath, error) {
 
 	basePath := "/dev/input"
 
-	files, err := ioutil.ReadDir(basePath)
+	files, err := os.ReadDir(basePath)
 	if err != nil {
 		return list, err
 	}


### PR DESCRIPTION
Small warning fix : package ioutil is deprecated since go 1.16