### PR TITLE
evdev: support for kernel input filtering (inputmask)

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -1,10 +1,33 @@
 package evdev
 
 type bitmap struct {
+	// TODO: Consider making this a []uintptr given that the kernels'
+	// bits_from_user requires bitmasks to be long-sized. That would also avoid
+	// alignment problems, if any.
 	bits []byte
 }
 
-func (bm *bitmap) bitIsSet(bit int) bool {
+func (bm bitmap) set(bit int) {
+	if bit < 0 || bit >= len(bm.bits)*8 {
+		return
+	}
+	bm.bits[bit/8] |= (1 << (bit % 8))
+}
+
+func (bm bitmap) clear(bit int) {
+	if bit < 0 || bit >= len(bm.bits)*8 {
+		return
+	}
+	bm.bits[bit/8] &^= (1 << (bit % 8))
+}
+
+func (bm bitmap) setAll() {
+	for i := range bm.bits {
+		bm.bits[i] = 0xFF
+	}
+}
+
+func (bm bitmap) bitIsSet(bit int) bool {
 	if bit > len(bm.bits)*8 {
 		return false
 	}
@@ -12,7 +35,7 @@ func (bm *bitmap) bitIsSet(bit int) bool {
 	return bm.bits[bit/8]&(1<<(bit%8)) != 0
 }
 
-func (bm *bitmap) setBits() []int {
+func (bm bitmap) setBits() []int {
 	var a []int
 
 	for i, by := range bm.bits {
@@ -26,8 +49,8 @@ func (bm *bitmap) setBits() []int {
 	return a
 }
 
-func newBitmap(bits []byte) *bitmap {
-	return &bitmap{
+func newBitmap(bits []byte) bitmap {
+	return bitmap{
 		bits: bits,
 	}
 }

--- a/device.go
+++ b/device.go
@@ -5,7 +5,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"runtime"
 	"syscall"
+	"unsafe"
 )
 
 // InputDevice represent a Linux kernel input device in userspace.
@@ -217,6 +219,89 @@ func (d *InputDevice) State(t EvType) (StateMap, error) {
 	}
 
 	return st, nil
+}
+
+// SetMask masks the events in mask for the event type of the mask. Other event
+// types are unaffected. The filter is applied at the kernel level.
+//
+// If successful, SetMask overrides any previous mask set for the event type.
+//
+// Not every event type can be filtered (an example is EV_SYN). The kernel may
+// fail to filter events, always check the error.
+//
+// Usage examples (error checking omitted for brevity):
+//
+// Produce no key-press events:
+//
+//	evdev.SetMask(evdev.AllowMask(evdev.EV_KEY, nil))
+//
+// Only produce BTN_SOUTH and BTN_EAST (from EV_KEY) events.
+//
+//	evdev.SetMask(evdev.AllowMask(evdev.EV_KEY, evdev.EvCode{
+//	  evdev.BTN_SOUTH,
+//	  evdev.BTN_EAST,
+//	}))
+//
+// Produce all EV_KEY events except for BTN_NORTH:
+//
+//	evdev.SetMask(evdev.DenyMask(evdev.EV_KEY, evdev.EvCode{
+//	  evdev.BTN_NORTH,
+//	}))
+//
+// Only allow EV_KEY (by silencing all other event types):
+//
+//	for _, evtype := range dev.CapableTypes() {
+//		if evtype == evdev.EV_KEY || evtype == evdev.EV_SYN {
+//			continue // Don't silence EV_KEY, and EV_SYN can't be silenced.
+//		}
+//
+//		mask := evdev.AllowMask(evtype, nil) // Allow nothing.
+//		if err := dev.SetMask(mask); err != nil { ... }
+//	}
+//
+// NOTE: Unsetting a filter is not supported. The effect can be achieved by
+// passing evdev.DenyMask(evtype, nil), though it is not strictly the same due
+// to the kernel potentially knowing about more events. It is recommended to
+// close and re-open the [InputDevice] to reset.
+func (d *InputDevice) SetMask(mask Mask) error {
+	// EV_SYN cannot be filtered, don't even try (see __evdev_is_filtered in
+	// drivers/input/evdev.c).
+	if mask.typ == EV_SYN {
+		return fmt.Errorf("the kernel does not allow masking EV_SYN")
+	}
+	cnt := countForType(mask.typ)
+	if cnt == 0 {
+		return fmt.Errorf("could not size mask for unknown event type %d", mask.typ)
+	}
+
+	// Calculate required bytes for bitmask. The bitmask must be long (uintptr)
+	// sized, even when the bitmap itself would require fewer bytes.
+	//
+	// EVIOCSMASK passes this size as codes_size to the bits_from_user() in the
+	// kernel, which requires `codes_size % sizeof(long) == 0`.
+	const (
+		bytesPerWord = unsafe.Sizeof(uintptr(0))
+		bitsPerWord  = bytesPerWord * 8
+	)
+	words := (uintptr(cnt) + bitsPerWord - 1) / bitsPerWord
+	bits := newBitmap(make([]byte, words*bytesPerWord))
+
+	if mask.allow {
+		for _, code := range mask.codes {
+			bits.set(int(code))
+		}
+	} else {
+		bits.setAll()
+		for _, code := range mask.codes {
+			bits.clear(int(code))
+		}
+	}
+	defer runtime.KeepAlive(bits.bits)
+	return ioctlEVIOCSMASK(d.file.Fd(), InputMask{
+		Type:      uint32(mask.typ),
+		CodesSize: uint32(len(bits.bits)),
+		CodesPtr:  uint64(uintptr(unsafe.Pointer(&bits.bits[0]))),
+	})
 }
 
 // AbsInfos returns the AbsInfo struct for all axis the device supports.

--- a/device.go
+++ b/device.go
@@ -296,7 +296,12 @@ func (d *InputDevice) SetMask(mask Mask) error {
 			bits.clear(int(code))
 		}
 	}
+	// Ensure the GC does not collected the bitmask until _after_ the ioctl has
+	// returned. An alternative would be to make [CodesPtr] an [unsafe.Pointer],
+	// but that would not work well on 32-bit as the kernel still expects a 64-bit
+	// integer.
 	defer runtime.KeepAlive(bits.bits)
+
 	return ioctlEVIOCSMASK(d.file.Fd(), InputMask{
 		Type:      uint32(mask.typ),
 		CodesSize: uint32(len(bits.bits)),

--- a/ioctl.go
+++ b/ioctl.go
@@ -1,6 +1,7 @@
 package evdev
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"strings"
@@ -139,35 +140,43 @@ func ioctlEVIOCGSW(fd uintptr) ([]byte, error) {
 	return bits[:], err
 }
 
-func ioctlEVIOCGBIT(fd uintptr, evtype int) ([]byte, error) {
-	var cnt int
+func ioctlEVIOCSMASK(fd uintptr, mask InputMask) error {
+	code := ioctlMakeCode(ioctlDirWrite, 'E', 0x93, unsafe.Sizeof(mask))
+	return doIoctl(fd, code, unsafe.Pointer(&mask))
+}
 
-	switch evtype {
-	case 0:
+// Userspace version of evdev_get_mask_cnt from linux/drivers/input/evdev.c.
+func countForType(t EvType) int {
+	switch t {
+	case EV_SYN: // == 0
 		// special case, indicating the list of all feature types supported should be returned,
 		// rather than the list of particular features for that type
-		cnt = EV_CNT
+		return EV_CNT
 	case EV_KEY:
-		cnt = KEY_CNT
+		return KEY_CNT
 	case EV_REL:
-		cnt = REL_CNT
+		return REL_CNT
 	case EV_ABS:
-		cnt = ABS_CNT
+		return ABS_CNT
 	case EV_MSC:
-		cnt = MSC_CNT
+		return MSC_CNT
 	case EV_SW:
-		cnt = SW_CNT
+		return SW_CNT
 	case EV_LED:
-		cnt = LED_CNT
+		return LED_CNT
 	case EV_SND:
-		cnt = SND_CNT
+		return SND_CNT
 	case EV_REP:
-		cnt = REP_CNT
+		return REP_CNT
 	case EV_FF:
-		cnt = FF_CNT
+		return FF_CNT
 	default: // EV_PWR, EV_FF_STATUS ??
-		cnt = KEY_MAX
+		return 0
 	}
+}
+
+func ioctlEVIOCGBIT(fd uintptr, evtype int) ([]byte, error) {
+	cnt := cmp.Or(countForType(EvType(evtype)), KEY_MAX) // TODO: handle truncation.
 
 	bytesNumber := (cnt + 7) / 8
 

--- a/ioctl.go
+++ b/ioctl.go
@@ -145,8 +145,9 @@ func ioctlEVIOCSMASK(fd uintptr, mask InputMask) error {
 	return doIoctl(fd, code, unsafe.Pointer(&mask))
 }
 
-// Userspace version of evdev_get_mask_cnt from linux/drivers/input/evdev.c.
-func countForType(t EvType) int {
+// count returns an upper bound on the number of distinct events in t. Userspace
+// version of evdev_get_mask_cnt from linux/drivers/input/evdev.c.
+func (t EvType) count() int {
 	switch t {
 	case EV_SYN: // == 0
 		// special case, indicating the list of all feature types supported should be returned,
@@ -176,7 +177,7 @@ func countForType(t EvType) int {
 }
 
 func ioctlEVIOCGBIT(fd uintptr, evtype int) ([]byte, error) {
-	cnt := cmp.Or(countForType(EvType(evtype)), KEY_MAX) // TODO: handle truncation.
+	cnt := cmp.Or(EvType(evtype).count(), KEY_MAX) // TODO: handle truncation.
 
 	bytesNumber := (cnt + 7) / 8
 

--- a/mask.go
+++ b/mask.go
@@ -1,0 +1,25 @@
+package evdev
+
+type Mask struct {
+	typ   EvType // EV_KEY, ...
+	allow bool   // Is an allowlist or a denylist?
+	codes []EvCode
+}
+
+// DenyMask returns a mask that will deny [codes] when passed to
+// [InputDevice.SetMask]. If codes is empty, all events of type typ are
+// returned.
+func DenyMask(typ EvType, codes []EvCode) Mask {
+	return Mask{
+		typ:   typ,
+		codes: codes,
+	}
+}
+
+// AllowMask returns a mask that will allow [codes] when passed to
+// [InputDevice.SetMask]. If codes is empty, no events of type typ are returned.
+func AllowMask(typ EvType, codes []EvCode) Mask {
+	m := DenyMask(typ, codes)
+	m.allow = true
+	return m
+}

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package evdev
 
 import (
 	"fmt"
+	"structs"
 	"syscall"
 	"unsafe"
 )
@@ -70,8 +71,9 @@ type InputKeymapEntry struct {
 	ScanCode [32]uint8
 }
 
-// InputMask ...
+// InputMask is used for filtering events.
 type InputMask struct {
+	_         structs.HostLayout
 	Type      uint32
 	CodesSize uint32
 	CodesPtr  uint64


### PR DESCRIPTION
By adding a SetMask/AllowMask/DenyMask API.

There are some warts on this API, like being able to do this apparently non-sensical thing without errors:

    mask := evdev.AllowMask(evdev.EV_ABS, evdev.EvCode{evdev.BTN_NORTH})

Despite BTN_NORTH not being an ABS event. This would be solveable (I believe) if the event types had types. Pseudo-code:

    type EventKey[T ~EvCode]

    type SynCode uint16
    type KeyCode uint16

    const (
            EV_SYN  EventKey[SynCode] = 0x00
            EV_KEY  EventKey[KeyCode] = 0x01
            // ...
    )

    const (
            KEY_RESERVED KeyCode  = 0
            KEY_ESC      KeyCode  = 1
            // ...
    )

However, this would not be backwards compatible at all (and I say this without prototyping the feasibility).

I spent quite some time finagling with hard-to-explain errors, until I found out that the kernel requires bitmasks to be sized in word (uintptr) increments.

Closes #20.